### PR TITLE
Fix updating of automation rules on app deployment

### DIFF
--- a/library/helpers/js_4me_deploy_helper.js
+++ b/library/helpers/js_4me_deploy_helper.js
@@ -311,7 +311,7 @@ class Js4meDeployHelper {
     const results = [];
     for (let i = 0; i < currentRules.length; i++) {
       const ruleId = currentRules[i].id;
-      if (i < offeringRuleInputs.length) {
+      if (i < offeringRuleInputs.length && offeringRuleInputs[i]) {
         const newRule = offeringRuleInputs[i];
         const upsertResult = await this.upsertOfferingAutomationRule(js4meHelper,
                                                                      accessToken,
@@ -355,6 +355,7 @@ class Js4meDeployHelper {
         groups[generic] = [[], []];
       }
       groups[generic][0].push(currentRule);
+      groups[generic][1].push(null);
     }
     const newRules = offeringRuleInputs || [];
     for (let i = 0; i < newRules.length; i++) {
@@ -363,7 +364,13 @@ class Js4meDeployHelper {
       if (!groups[generic]) {
         groups[generic] = [[], []];
       }
-      groups[generic][1].push(newRule);
+      const currentRules = groups[generic][0];
+      const currentRuleIndex = currentRules.findIndex(r => r.name === newRule.name);
+      if (currentRuleIndex >= 0) {
+        groups[generic][1][currentRuleIndex] = newRule;
+      } else {
+        groups[generic][1].push(newRule);
+      }
     }
     return groups;
   }

--- a/library/helpers/tests/js_4me_deploy_helper.test.js
+++ b/library/helpers/tests/js_4me_deploy_helper.test.js
@@ -1,0 +1,225 @@
+'use strict';
+
+const Js4meDeployHelper = require('../js_4me_deploy_helper');
+
+describe('grouping automation rules by record type', () => {
+  test('rules with same generic value', () => {
+    const jsHelper = new Js4meDeployHelper();
+    const existingRules = [
+      {
+        "id": "abc",
+        "name": "Trigger webhook for each note added",
+        "generic": "request"
+      },
+      {
+        "id": "def",
+        "name": "Trigger webhook for status changed",
+        "generic": "request"
+      },
+    ];
+    const inputRules = [
+      {
+        "name": "Trigger webhook for each note added updated",
+        "generic": "request"
+      },
+    ];
+    const grouped = jsHelper.groupOfferingAutomationRules(existingRules, inputRules);
+    expect(Object.keys(grouped)).toEqual(['request']);
+    expect(grouped['request']).toEqual([existingRules, inputRules]);
+  });
+
+  test('rules with different generic value', () => {
+    const jsHelper = new Js4meDeployHelper();
+    const existingRules = [
+      {
+        "id": "abc",
+        "name": "Trigger webhook for each note added",
+        "generic": "request"
+      },
+      {
+        "id": "def",
+        "name": "Trigger webhook for status changed",
+        "generic": "request"
+      },
+    ];
+    const inputRules = [
+      {
+        "name": "Trigger webhook for each note added updated",
+        "generic": "task"
+      },
+    ];
+    const grouped = jsHelper.groupOfferingAutomationRules(existingRules, inputRules);
+    expect(Object.keys(grouped)).toEqual(['request', 'task']);
+    expect(grouped['request']).toEqual([existingRules, []]);
+    expect(grouped['task']).toEqual([[], inputRules]);
+  });
+
+  test('all new rules', () => {
+    const jsHelper = new Js4meDeployHelper();
+    const inputRules = [
+      {
+        "name": "Trigger webhook for each note added updated",
+        "generic": "task"
+      },
+    ];
+    const grouped = jsHelper.groupOfferingAutomationRules(null, inputRules);
+    expect(Object.keys(grouped)).toEqual(['task']);
+    expect(grouped['task']).toEqual([[], inputRules]);
+  });
+
+
+  test('remove all current rules', () => {
+    const jsHelper = new Js4meDeployHelper();
+    const existingRules = [
+      {
+        "id": "abc",
+        "name": "Trigger webhook for each note added",
+        "generic": "request"
+      },
+      {
+        "id": "def",
+        "name": "Trigger webhook for status changed",
+        "generic": "request"
+      },
+    ];
+    const grouped = jsHelper.groupOfferingAutomationRules(existingRules, null);
+    expect(Object.keys(grouped)).toEqual(['request']);
+    expect(grouped['request']).toEqual([existingRules, []]);
+  });
+
+  test('mixed rules remove one', () => {
+    const jsHelper = new Js4meDeployHelper();
+    const existingRules = [
+      {
+        "id": "abc",
+        "name": "Trigger webhook for each note added",
+        "generic": "request"
+      },
+      {
+        "id": "xyz",
+        "name": "Trigger webhook for each note added updated",
+        "generic": "request"
+      },
+      {
+        "id": "def",
+        "name": "Trigger webhook for status changed",
+        "generic": "task"
+      },
+    ];
+    const inputRules = [
+      {
+        "name": "Trigger webhook for each note added",
+        "generic": "request"
+      },
+      {
+        "name": "Trigger webhook for status changed",
+        "generic": "task"
+      },
+    ];
+    const grouped = jsHelper.groupOfferingAutomationRules(existingRules, inputRules);
+    expect(Object.keys(grouped)).toEqual(['request', 'task']);
+    expect(grouped['request']).toEqual([[existingRules[0], existingRules[1]], [inputRules[0]]]);
+    expect(grouped['task']).toEqual([[existingRules[2]], [inputRules[1]]]);
+  });
+
+  test('mixed rules add one', () => {
+    const jsHelper = new Js4meDeployHelper();
+    const existingRules = [
+      {
+        "id": "abc",
+        "name": "Trigger webhook for each note added",
+        "generic": "request"
+      },
+      {
+        "id": "def",
+        "name": "Trigger webhook for status changed",
+        "generic": "task"
+      },
+    ];
+    const inputRules = [
+      {
+        "name": "Trigger webhook for each note added",
+        "generic": "request"
+      },
+      {
+        "name": "Trigger webhook for each note added extra",
+        "generic": "request"
+      },
+      {
+        "name": "Trigger webhook for status changed",
+        "generic": "task"
+      },
+    ];
+    const grouped = jsHelper.groupOfferingAutomationRules(existingRules, inputRules);
+    expect(Object.keys(grouped)).toEqual(['request', 'task']);
+    expect(grouped['request']).toEqual([[existingRules[0]], [inputRules[0], inputRules[1]]]);
+    expect(grouped['task']).toEqual([[existingRules[1]], [inputRules[2]]]);
+  });
+
+  test('mixed rules remove all one type', () => {
+    const jsHelper = new Js4meDeployHelper();
+    const existingRules = [
+      {
+        "id": "abc",
+        "name": "Trigger webhook for each note added",
+        "generic": "request"
+      },
+      {
+        "id": "xyz",
+        "name": "Trigger webhook for each note added updated",
+        "generic": "request"
+      },
+      {
+        "id": "def",
+        "name": "Trigger webhook for status changed",
+        "generic": "task"
+      },
+    ];
+    const inputRules = [
+      {
+        "name": "Trigger webhook for status changed",
+        "generic": "task"
+      },
+    ];
+    const grouped = jsHelper.groupOfferingAutomationRules(existingRules, inputRules);
+    expect(Object.keys(grouped)).toEqual(['request', 'task']);
+    expect(grouped['request']).toEqual([[existingRules[0], existingRules[1]], []]);
+    expect(grouped['task']).toEqual([[existingRules[2]], [inputRules[0]]]);
+  });
+
+  test('non generic rules', () => {
+    const jsHelper = new Js4meDeployHelper();
+    const existingRules = [
+      {
+        "id": "abc",
+        "name": "Trigger webhook for each note added",
+      },
+      {
+        "id": "xyz",
+        "name": "Trigger webhook for each note added updated",
+      },
+    ];
+    const inputRules = [
+      {
+        "name": "Trigger webhook for status changed",
+      },
+    ];
+    const grouped = jsHelper.groupOfferingAutomationRules(existingRules, inputRules);
+    expect(Object.keys(grouped)).toEqual(['undefined']);
+    expect(grouped['undefined']).toEqual([[existingRules[0], existingRules[1]], [inputRules[0]]]);
+  });
+
+  test('no rules', () => {
+    const jsHelper = new Js4meDeployHelper();
+    const grouped = jsHelper.groupOfferingAutomationRules([], []);
+    expect(Object.keys(grouped)).toEqual([]);
+    expect(grouped).toEqual({});
+  });
+
+  test('null rules', () => {
+    const jsHelper = new Js4meDeployHelper();
+    const grouped = jsHelper.groupOfferingAutomationRules(null, null);
+    expect(Object.keys(grouped)).toEqual([]);
+    expect(grouped).toEqual({});
+  });
+});

--- a/library/helpers/tests/js_4me_deploy_helper.test.js
+++ b/library/helpers/tests/js_4me_deploy_helper.test.js
@@ -25,7 +25,7 @@ describe('grouping automation rules by record type', () => {
     ];
     const grouped = jsHelper.groupOfferingAutomationRules(existingRules, inputRules);
     expect(Object.keys(grouped)).toEqual(['request']);
-    expect(grouped['request']).toEqual([existingRules, inputRules]);
+    expect(grouped['request']).toEqual([existingRules, [null, null, ...inputRules]]);
   });
 
   test('rules with different generic value', () => {
@@ -50,7 +50,7 @@ describe('grouping automation rules by record type', () => {
     ];
     const grouped = jsHelper.groupOfferingAutomationRules(existingRules, inputRules);
     expect(Object.keys(grouped)).toEqual(['request', 'task']);
-    expect(grouped['request']).toEqual([existingRules, []]);
+    expect(grouped['request']).toEqual([existingRules, [null, null]]);
     expect(grouped['task']).toEqual([[], inputRules]);
   });
 
@@ -66,7 +66,6 @@ describe('grouping automation rules by record type', () => {
     expect(Object.keys(grouped)).toEqual(['task']);
     expect(grouped['task']).toEqual([[], inputRules]);
   });
-
 
   test('remove all current rules', () => {
     const jsHelper = new Js4meDeployHelper();
@@ -84,7 +83,42 @@ describe('grouping automation rules by record type', () => {
     ];
     const grouped = jsHelper.groupOfferingAutomationRules(existingRules, null);
     expect(Object.keys(grouped)).toEqual(['request']);
-    expect(grouped['request']).toEqual([existingRules, []]);
+    expect(grouped['request']).toEqual([existingRules, [null, null]]);
+  });
+
+  test('mixed rules remove first', () => {
+    const jsHelper = new Js4meDeployHelper();
+    const existingRules = [
+      {
+        "id": "abc",
+        "name": "Trigger webhook for each note added",
+        "generic": "request"
+      },
+      {
+        "id": "xyz",
+        "name": "Trigger webhook for each note added updated",
+        "generic": "request"
+      },
+      {
+        "id": "def",
+        "name": "Trigger webhook for status changed",
+        "generic": "task"
+      },
+    ];
+    const inputRules = [
+      {
+        "name": "Trigger webhook for each note added updated",
+        "generic": "request"
+      },
+      {
+        "name": "Trigger webhook for status changed",
+        "generic": "task"
+      },
+    ];
+    const grouped = jsHelper.groupOfferingAutomationRules(existingRules, inputRules);
+    expect(Object.keys(grouped)).toEqual(['request', 'task']);
+    expect(grouped['request']).toEqual([[existingRules[0], existingRules[1]], [null, inputRules[0]]]);
+    expect(grouped['task']).toEqual([[existingRules[2]], [inputRules[1]]]);
   });
 
   test('mixed rules remove one', () => {
@@ -118,7 +152,7 @@ describe('grouping automation rules by record type', () => {
     ];
     const grouped = jsHelper.groupOfferingAutomationRules(existingRules, inputRules);
     expect(Object.keys(grouped)).toEqual(['request', 'task']);
-    expect(grouped['request']).toEqual([[existingRules[0], existingRules[1]], [inputRules[0]]]);
+    expect(grouped['request']).toEqual([[existingRules[0], existingRules[1]], [inputRules[0], null]]);
     expect(grouped['task']).toEqual([[existingRules[2]], [inputRules[1]]]);
   });
 
@@ -183,7 +217,7 @@ describe('grouping automation rules by record type', () => {
     ];
     const grouped = jsHelper.groupOfferingAutomationRules(existingRules, inputRules);
     expect(Object.keys(grouped)).toEqual(['request', 'task']);
-    expect(grouped['request']).toEqual([[existingRules[0], existingRules[1]], []]);
+    expect(grouped['request']).toEqual([[existingRules[0], existingRules[1]], [null, null]]);
     expect(grouped['task']).toEqual([[existingRules[2]], [inputRules[0]]]);
   });
 
@@ -206,7 +240,7 @@ describe('grouping automation rules by record type', () => {
     ];
     const grouped = jsHelper.groupOfferingAutomationRules(existingRules, inputRules);
     expect(Object.keys(grouped)).toEqual(['undefined']);
-    expect(grouped['undefined']).toEqual([[existingRules[0], existingRules[1]], [inputRules[0]]]);
+    expect(grouped['undefined']).toEqual([[existingRules[0], existingRules[1]], [null, null, inputRules[0]]]);
   });
 
   test('no rules', () => {


### PR DESCRIPTION
Two possible problems could occur when an app tried to updates automation rules, because the deploy process worked index based on all automation rules of the app:

- when the app had rules on multiple record types this could lead to an attempt to change the record type the rule worked on (which is not possible)
- when automation rules were deleted which were not the last ones added duplicate names could (temporarily) be created and 4me does not allow that