### PR TITLE
Use operatingSystem.name instead of caption

### DIFF
--- a/lansweeper/aws/integration-lambda/discovery_mutation_helper.js
+++ b/lansweeper/aws/integration-lambda/discovery_mutation_helper.js
@@ -103,8 +103,8 @@ class DiscoveryMutationHelper {
         ci.ciRelations = {childIds: softwareIDs};
       }
     }
-    if (asset.operatingSystem && asset.operatingSystem.caption) {
-      const softwareIDs = this.mapSoftwareName([asset.operatingSystem.caption]);
+    if (asset.operatingSystem && asset.operatingSystem.name) {
+      const softwareIDs = this.mapSoftwareName([asset.operatingSystem.name]);
       if (softwareIDs.length > 0) {
         ci.operatingSystemId = softwareIDs[0];
       }

--- a/lansweeper/aws/integration-lambda/lansweeper_client.js
+++ b/lansweeper/aws/integration-lambda/lansweeper_client.js
@@ -313,8 +313,8 @@ LansweeperClient.basicInfoFields = 'name type description ipAddress firstSeen la
 LansweeperClient.assetCustomFields = 'model manufacturer stateName purchaseDate warrantyDate serialNumber sku';
 LansweeperClient.usersFields = 'name email fullName';
 LansweeperClient.softwaresFields = 'name';
-LansweeperClient.operatingSystemFields = 'caption version';
-LansweeperClient.osMetadataFields = 'name version endOfSupportDate';
+LansweeperClient.operatingSystemFields = 'name';
+LansweeperClient.osMetadataFields = 'name endOfSupportDate';
 LansweeperClient.processorFields = 'numberOfCores';
 LansweeperClient.memoryModulesFields = 'size';
 

--- a/lansweeper/aws/integration-lambda/lansweeper_client.js
+++ b/lansweeper/aws/integration-lambda/lansweeper_client.js
@@ -313,8 +313,8 @@ LansweeperClient.basicInfoFields = 'name type description ipAddress firstSeen la
 LansweeperClient.assetCustomFields = 'model manufacturer stateName purchaseDate warrantyDate serialNumber sku';
 LansweeperClient.usersFields = 'name email fullName';
 LansweeperClient.softwaresFields = 'name';
-LansweeperClient.operatingSystemFields = 'caption name';
-LansweeperClient.osMetadataFields = 'name endOfSupportDate';
+LansweeperClient.operatingSystemFields = 'caption version';
+LansweeperClient.osMetadataFields = 'name version endOfSupportDate';
 LansweeperClient.processorFields = 'numberOfCores';
 LansweeperClient.memoryModulesFields = 'size';
 

--- a/lansweeper/aws/integration-lambda/lansweeper_helper.js
+++ b/lansweeper/aws/integration-lambda/lansweeper_helper.js
@@ -67,21 +67,21 @@ class LansweeperHelper {
   }
 
   extractOperatingSystemNames(assets) {
-    const oss = assets.map(a => a.operatingSystem).filter(os => !!os && !!os.caption);
-    return this.mapToUnique(oss, os => this.cleanupName(os.caption));
+    const oss = assets.map(a => a.operatingSystem).filter(os => !!os && !!os.name);
+    return this.mapToUnique(oss, os => this.cleanupName(os.name));
   }
 
   extractOperatingSystemEndOfSupport(assets) {
     const endOfSupportDates = new Map();
     for (const asset of assets) {
-      if (asset.operatingSystem && asset.operatingSystem.caption &&
+      if (asset.operatingSystem && asset.operatingSystem.name &&
         asset.recognitionInfo && asset.recognitionInfo.osMetadata) {
         const metadata = asset.recognitionInfo.osMetadata;
         if (metadata.name && metadata.endOfSupportDate) {
-          const caption = this.cleanupName(asset.operatingSystem.caption);
+          const name = this.cleanupName(asset.operatingSystem.name);
           const metaName = this.cleanupName(metadata.name);
-          if (caption.includes(metaName)) {
-            endOfSupportDates.set(caption, metadata.endOfSupportDate);
+          if (name.includes(metaName)) {
+            endOfSupportDates.set(name, metadata.endOfSupportDate);
           }
         }
       }
@@ -151,8 +151,8 @@ class LansweeperHelper {
     return known;
   }
 
-  mapToUnique(assets, getFunction) {
-    return assets.map(getFunction)
+  mapToUnique(objects, getFunction) {
+    return objects.map(getFunction)
       .filter((v, i, a) => v && a.indexOf(v) === i);
   }
 

--- a/lansweeper/aws/integration-lambda/lansweeper_helper.js
+++ b/lansweeper/aws/integration-lambda/lansweeper_helper.js
@@ -82,6 +82,8 @@ class LansweeperHelper {
           const metaName = this.cleanupName(metadata.name);
           if (name.includes(metaName)) {
             endOfSupportDates.set(name, metadata.endOfSupportDate);
+          } else {
+            console.warn(`operatingSystem and osMetadata mismatch: '${asset.operatingSystem.name}' vs '${metadata.name}'`);
           }
         }
       }

--- a/lansweeper/aws/integration-lambda/lansweeper_helper.js
+++ b/lansweeper/aws/integration-lambda/lansweeper_helper.js
@@ -6,7 +6,6 @@ class LansweeperHelper {
     this.brands = {};
     this.models = {};
     this.products = {};
-    this.osNameMismatches = new Map();
   }
 
   extractProductCategories(assets) {
@@ -68,33 +67,8 @@ class LansweeperHelper {
   }
 
   extractOperatingSystemNames(assets) {
-    const oss = assets.map(a => a.operatingSystem).filter(os => !!os);
-    this.captureOsMismatches(oss);
-    const captions = oss.filter(os => !!os.caption);
-    return this.mapToUnique(captions, os => this.cleanupName(os.caption));
-  }
-
-  captureOsMismatches(oss) {
-    for (const os of oss) {
-      const cleanCaption = os.caption && this.cleanupName(os.caption);
-      const cleanName = os.name && this.cleanupName(os.name);
-      let message = null;
-      if (cleanCaption && !cleanName) {
-        message = `No name for ${cleanCaption}`;
-      } else if (!cleanCaption && cleanName) {
-        message = `No caption for ${cleanName}`;
-      } else if (cleanCaption && cleanName && cleanCaption !== cleanName) {
-        message = `Mismatch between caption and name: '${cleanCaption}' != '${cleanName}'`;
-      }
-      if (message) {
-        const currentCount = this.osNameMismatches.get(message);
-        if (currentCount) {
-          this.osNameMismatches.set(message, currentCount + 1);
-        } else {
-          this.osNameMismatches.set(message, 1);
-        }
-      }
-    }
+    const oss = assets.map(a => a.operatingSystem).filter(os => !!os && !!os.caption);
+    return this.mapToUnique(oss, os => this.cleanupName(os.caption));
   }
 
   extractOperatingSystemEndOfSupport(assets) {
@@ -177,8 +151,8 @@ class LansweeperHelper {
     return known;
   }
 
-  mapToUnique(objects, getFunction) {
-    return objects.map(getFunction)
+  mapToUnique(assets, getFunction) {
+    return assets.map(getFunction)
       .filter((v, i, a) => v && a.indexOf(v) === i);
   }
 

--- a/lansweeper/aws/integration-lambda/lansweeper_integration.js
+++ b/lansweeper/aws/integration-lambda/lansweeper_integration.js
@@ -101,12 +101,6 @@ class LansweeperIntegration {
         result.info['operatingSystems'] = `Stored end-of-support for ${cisUpdated.length} item(s)`;
       }
     }
-    const osNameMismatches = this.referenceHelper?.lansweeperHelper?.osNameMismatches;
-    if (osNameMismatches && osNameMismatches.size > 0) {
-      osNameMismatches.forEach((count, message) => {
-        console.log(`OS name mismatch: ${message}; count: ${count}`)
-      });
-    }
     if (this.referenceHelper.peopleFound.size > 0 || this.referenceHelper.peopleNotFound.length > 0) {
       console.log(`User lookup: found ${this.referenceHelper.peopleFound.size} people (not found ${this.referenceHelper.peopleNotFound.length})`);
     }

--- a/lansweeper/aws/integration-lambda/os_ci_mutation_helper.js
+++ b/lansweeper/aws/integration-lambda/os_ci_mutation_helper.js
@@ -28,10 +28,10 @@ class OsCiMutationHelper {
     }
     console.log('End of support dates: %j', [...osEndOfSupports]);
     const cisToUpdate = [];
-    for (const osCaption of osEndOfSupports.keys()) {
-      const ciId = ciIds.get(osCaption);
+    for (const osNames of osEndOfSupports.keys()) {
+      const ciId = ciIds.get(osNames);
       if (ciId) {
-        const endOfSupportDate = osEndOfSupports.get(osCaption);
+        const endOfSupportDate = osEndOfSupports.get(osNames);
         cisToUpdate.push({id: ciId, endOfSupportDate: endOfSupportDate});
       }
     }

--- a/lansweeper/aws/integration-lambda/tests/assets/asset_array.json
+++ b/lansweeper/aws/integration-lambda/tests/assets/asset_array.json
@@ -12,9 +12,7 @@
       "lastChanged": "2023-03-01T16:08:54.427Z"
     },
     "operatingSystem": {
-      "version": "22H2",
-      "caption": "Microsoft Windows 11 Home",
-      "buildNumber": "10.0.22621"
+      "name": "Microsoft Windows 11 Home"
     },
     "memoryModules": [
       {
@@ -461,7 +459,7 @@
       "stateName": "Active"
     },
     "operatingSystem": {
-      "caption": "Microsoft Windows Server 2012 R2 Standard"
+      "name": "Microsoft Windows Server 2012 R2 Standard"
     },
     "softwares": [
       {
@@ -548,8 +546,7 @@
       "stateName": "Active"
     },
     "operatingSystem": {
-      "version": "16.04",
-      "caption": "Linux 16.04"
+      "name": "Linux 16.04"
     },
     "recognitionInfo": {
       "osMetadata": {
@@ -668,8 +665,7 @@
       "stateName": "Active"
     },
     "operatingSystem": {
-      "caption": "Microsoft Windows Server 2012 R2 Standard",
-      "buildNumber": "6.3.9600"
+      "name": "Microsoft Windows Server 2012 R2 Standard"
     },
     "users": [
       {
@@ -1150,8 +1146,7 @@
       "lastChanged": "2021-08-23T15:55:48.747Z"
     },
     "operatingSystem": {
-      "version": "18.04",
-      "caption": "Linux 18.04"
+      "name": "Linux 18.04"
     },
     "assetCustom": {
       "manufacturer": "VMware, Inc.",
@@ -1184,7 +1179,7 @@
       "stateName": "Active"
     },
     "operatingSystem": {
-      "caption": "Linux 16.04"
+      "name": "Red Hat Enterprise Linux 8.9 (Ootpa)"
     },
     "url": "https://app.lansweeper.com/jest-site/asset/MjEtQXNzZXQtZjNmNGRiMjMtMWJlNS00MDk1LWIyYTktODY5ZWE3YzFhZjEw/summary"
   },
@@ -1209,7 +1204,7 @@
       "stateName": "Active"
     },
     "operatingSystem": {
-      "caption": "Microsoft Windows Server 2019 Standard Evaluation"
+      "name": "Microsoft Windows Server 2019 Standard Evaluation"
     },
     "users": [
       {
@@ -1570,7 +1565,7 @@
       "stateName": "Active"
     },
     "operatingSystem": {
-      "caption": "Microsoft Windows Server 2019 Standard Evaluation"
+      "name": "Microsoft Windows Server 2019 Standard Evaluation"
     },
     "url": "https://app.lansweeper.com/jest-site/asset/NjYtQXNzZXQtZjNmNGRiMjMtMWJlNS00MDk1LWIyYTktODY5ZWE3YzFhZjEw/summary"
   },
@@ -2040,7 +2035,7 @@
       "stateName": "Active"
     },
     "operatingSystem": {
-      "caption": "Microsoft Windows Server 2012 R2 Standard"
+      "name": "Microsoft Windows Server 2012 R2 Standard"
     },
     "softwares": [
       {
@@ -2154,7 +2149,7 @@
       "lastChanged": "2023-03-20T06:20:51.537Z"
     },
     "operatingSystem": {
-      "version": "macOS"
+      "name": "macOS 14.4.1 (23E224)"
     },
     "assetCustom": {
       "manufacturer": "Apple",
@@ -2179,7 +2174,7 @@
       "lastChanged": "2023-03-21T06:23:07.403Z"
     },
     "operatingSystem": {
-      "version": "12"
+      "name": "Android"
     },
     "assetCustom": {
       "manufacturer": "Oppo",
@@ -2249,8 +2244,7 @@
       "lastChanged": "2021-08-23T15:56:04.153Z"
     },
     "operatingSystem": {
-      "version": "20.04",
-      "caption": "Linux 20.04"
+      "name": "Linux 20.04"
     },
     "assetCustom": {
       "manufacturer": "Dell Inc.",

--- a/lansweeper/aws/integration-lambda/tests/assets/asset_array.json
+++ b/lansweeper/aws/integration-lambda/tests/assets/asset_array.json
@@ -14,7 +14,6 @@
     "operatingSystem": {
       "version": "22H2",
       "caption": "Microsoft Windows 11 Home",
-      "name": "Microsoft Windows 11 Home",
       "buildNumber": "10.0.22621"
     },
     "memoryModules": [
@@ -1152,8 +1151,7 @@
     },
     "operatingSystem": {
       "version": "18.04",
-      "caption": "Linux 18.04",
-      "name": "Linux"
+      "caption": "Linux 18.04"
     },
     "assetCustom": {
       "manufacturer": "VMware, Inc.",
@@ -2156,7 +2154,6 @@
       "lastChanged": "2023-03-20T06:20:51.537Z"
     },
     "operatingSystem": {
-      "name": "macOS",
       "version": "macOS"
     },
     "assetCustom": {
@@ -2182,7 +2179,6 @@
       "lastChanged": "2023-03-21T06:23:07.403Z"
     },
     "operatingSystem": {
-      "name": "Android",
       "version": "12"
     },
     "assetCustom": {
@@ -2254,8 +2250,7 @@
     },
     "operatingSystem": {
       "version": "20.04",
-      "caption": "Linux 20.04",
-      "name": "Linux 20.04"
+      "caption": "Linux 20.04"
     },
     "assetCustom": {
       "manufacturer": "Dell Inc.",

--- a/lansweeper/aws/integration-lambda/tests/lansweeper_helper.test.js
+++ b/lansweeper/aws/integration-lambda/tests/lansweeper_helper.test.js
@@ -346,7 +346,10 @@ describe('extractOperatingSystemNames', () => {
                             'Microsoft Windows Server 2012 R2 Standard',
                             'Linux 16.04',
                             "Linux 18.04",
+                            'Red Hat Enterprise Linux 8.9 (Ootpa)',
                             'Microsoft Windows Server 2019 Standard Evaluation',
+                            'macOS 14.4.1 (23E224)',
+                            'Android',
                             "Linux 20.04",
                           ]);
   });

--- a/lansweeper/aws/integration-lambda/tests/lansweeper_helper.test.js
+++ b/lansweeper/aws/integration-lambda/tests/lansweeper_helper.test.js
@@ -333,15 +333,10 @@ describe('extractSoftwareNames', () => {
 });
 
 describe('extractOperatingSystemNames', () => {
-  beforeEach(() => {
-    helper.osNameMismatches.clear();
-  });
-
   it('handles empty', () => {
     const names = helper.extractOperatingSystemNames([]);
 
     expect(names).toEqual([]);
-    expect(helper.osNameMismatches.size).toEqual(0);
   });
 
   it('extracts unique values', () => {
@@ -354,25 +349,6 @@ describe('extractOperatingSystemNames', () => {
                             'Microsoft Windows Server 2019 Standard Evaluation',
                             "Linux 20.04",
                           ]);
-    expect(helper.osNameMismatches.size).toBeGreaterThan(0);
-  });
-
-  describe('capturesOsMismatches', () => {
-    it('counts mismatches', () => {
-      helper.extractOperatingSystemNames(assetArray);
-
-      expect([...helper.osNameMismatches.keys()])
-        .toEqual([
-                   "No name for Microsoft Windows Server 2012 R2 Standard",
-                   "No name for Linux 16.04",
-                   "Mismatch between caption and name: 'Linux 18.04' != 'Linux'",
-                   "No name for Microsoft Windows Server 2019 Standard Evaluation",
-                   "No caption for macOS",
-                   "No caption for Android",
-                 ]);
-      expect(helper.osNameMismatches.get("No name for Microsoft Windows Server 2012 R2 Standard")).toEqual(3);
-      expect(helper.osNameMismatches.get("No caption for macOS")).toEqual(1);
-    });
   });
 });
 

--- a/lansweeper/aws/integration-lambda/tests/references_helper.test.js
+++ b/lansweeper/aws/integration-lambda/tests/references_helper.test.js
@@ -77,7 +77,10 @@ describe('lookup4meReferences', () => {
                                                  "Microsoft Windows Server 2012 R2 Standard",
                                                  "Linux 16.04",
                                                  "Linux 18.04",
-                                                 "Microsoft Windows Server 2019 Standard Evaluation",
+                                                 'Red Hat Enterprise Linux 8.9 (Ootpa)',
+                                                 'Microsoft Windows Server 2019 Standard Evaluation',
+                                                 'macOS 14.4.1 (23E224)',
+                                                 'Android',
                                                  "Linux 20.04",
                                                ]);
     expect(helper.osEndOfSupports)


### PR DESCRIPTION
The operatingSystem.name field should provide better information (identical to value in Lansweeper UI) for Linux and MacOS.
For Microsoft Windows the content should be identical